### PR TITLE
Create TagsApiTest.java

### DIFF
--- a/src/test/java/io/spring/api/TagsApiTest.java
+++ b/src/test/java/io/spring/api/TagsApiTest.java
@@ -1,0 +1,54 @@
+package io.spring.api;
+
+import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.when;
+
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.spring.application.TagsQueryService;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(TagsApi.class)
+public class TagsApiTest {
+
+    @Autowired private MockMvc mvc;
+
+    @MockBean private TagsQueryService tagsQueryService;
+
+    @BeforeEach
+    public void setUp() {
+        RestAssuredMockMvc.mockMvc(mvc);
+    }
+
+    @Test
+    public void should_return_all_tags_success() {
+        List<String> expectedTags = Arrays.asList("tag1", "tag2", "tag3");
+        when(tagsQueryService.allTags()).thenReturn(expectedTags);
+
+        given()
+                .when()
+                .get("/tags")
+                .then()
+                .statusCode(200)
+                .body("tags", equalTo(expectedTags));
+    }
+
+    @Test
+    public void should_return_empty_list_when_no_tags() {
+        when(tagsQueryService.allTags()).thenReturn(Arrays.asList());
+
+        given()
+                .when()
+                .get("/tags")
+                .then()
+                .statusCode(200)
+                .body("tags", equalTo(Arrays.asList()));
+    }
+}


### PR DESCRIPTION
## **Type**
Tests


___

## **Description**
- Introduced a new test class `TagsApiTest` to validate the functionality of the Tags API.
- Implemented tests to ensure that the `/tags` endpoint correctly returns all tags and handles empty tag lists.
- Utilized `RestAssuredMockMvc` for setting up the mock MVC environment and `MockBean` for mocking the `TagsQueryService`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TagsApiTest.java</strong><dd><code>Add Tests for Tags API Endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/io/spring/api/TagsApiTest.java
<li>Created a new test class <code>TagsApiTest</code> for the Tags API.<br> <li> Added two test methods to verify the behavior of the <code>/tags</code> endpoint.<br> <li> Configured mock MVC and mocked <code>TagsQueryService</code> for testing.<br>


</details>
    

  </td>
  <td><a href="https://github.com/gologic-ca/Workshop-dette-technique/pull/3/files#diff-b467eb04ff2bd99a13d3bcbf54f4b0c234cf12cf0931fbc9976f235012507d08">+54/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

